### PR TITLE
switched to repeat-mode and introduced to ExecutionInfo-struct

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -5,8 +5,6 @@ on:
     branches:
       - develop
       - feature/*
-  pull_request:
-    branches: [develop]
 
 jobs:
   build:
@@ -35,6 +33,9 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: "1.23.3"
+
+      - uses: browser-actions/setup-chrome@v1
+      - run: chrome --version
 
       - name: System Tests
         run: go test -tags system_test -v ./...

--- a/main.go
+++ b/main.go
@@ -9,7 +9,8 @@ import (
 func main() {
 	screen := WebRTCScreen{}
 
-	go run(&screen, "/bin/bash", []string{"./simple-counter.sh", "0", "5"})
+	runnerDone := make(chan bool, 1)
+	go run(&screen, runnerDone, "/bin/bash", []string{"./simple-counter.sh", "0", "5"})
 
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, os.Interrupt)
@@ -18,6 +19,9 @@ func main() {
 	// 	for sig := range c {
 	// 	}
 	// }()
-	<-c
+	select {
+	case <-c:
+	case <-runnerDone:
+	}
 	fmt.Println("good bye!")
 }

--- a/main.go
+++ b/main.go
@@ -1,202 +1,23 @@
 package main
 
 import (
-	"encoding/base64"
-	"encoding/json"
 	"fmt"
-	"io"
-	"net/http"
 	"os"
-	"strings"
-	"time"
-
-	"github.com/pion/webrtc/v4"
+	"os/signal"
 )
 
 func main() {
-	resetSession()
-	ICEServers, err := getICEServersFromServer()
-	if err != nil {
-		fmt.Printf("E: while getting ICEServers-config: %v\n", err)
-		panic("check your internet connection")
-	}
-	config := webrtc.Configuration{
-		ICEServers: ICEServers,
-	}
+	screen := WebRTCScreen{}
 
-	reset := make(chan bool, 1)
-	screen := Screen{}
+	go run(&screen, "/bin/bash", []string{"./simple-counter.sh", "0", "5"})
 
-	go run(&screen, "/bin/bash", []string{"./simple-counter.sh", "5"})
-
-	for {
-		// Create a new RTCPeerConnection
-		peerConnection, err := webrtc.NewPeerConnection(config)
-		if err != nil {
-			panic(err)
-		}
-		defer func() {
-			if cErr := peerConnection.Close(); cErr != nil {
-				fmt.Printf("cannot close peerConnection: %v\n", cErr)
-			}
-		}()
-
-		peerConnection.OnConnectionStateChange(func(s webrtc.PeerConnectionState) {
-			fmt.Printf("Peer Connection State has changed: %s\n", s.String())
-
-			if s == webrtc.PeerConnectionStateFailed {
-				fmt.Println("Peer Connection has gone to failed exiting")
-				resetSession()
-				reset <- true
-			}
-
-			if s == webrtc.PeerConnectionStateClosed {
-				fmt.Println("Peer Connection has gone to closed exiting")
-				resetSession()
-				reset <- true
-			}
-		})
-
-		peerConnection.OnDataChannel(func(d *webrtc.DataChannel) {
-			fmt.Printf("New DataChannel %s %d\n", d.Label(), d.ID())
-
-			d.OnOpen(func() {
-				fmt.Printf("Data channel '%s'-'%d' open.\n", d.Label(), d.ID())
-
-				ticker := time.NewTicker(2 * time.Second)
-				defer ticker.Stop()
-				for range ticker.C {
-					// fmt.Printf("Sending '%s'\n", screen.text)
-					err = d.SendText(screen.text)
-					if err != nil {
-						fmt.Printf("E: while sending: %v\n", err)
-						break
-					}
-				}
-			})
-
-			d.OnMessage(func(msg webrtc.DataChannelMessage) {
-				fmt.Printf("Message from DataChannel '%s': '%s'\n", d.Label(), string(msg.Data))
-			})
-		})
-
-		// Waiting for and Import client-offer from signaling-server
-		offerData := repeat(getOfferFromServer, 2*time.Second)
-		offer := webrtc.SessionDescription{}
-		decode(offerData, &offer)
-		err = peerConnection.SetRemoteDescription(offer)
-		if err != nil {
-			panic(err)
-		}
-
-		// Create an answer
-		answer, err := peerConnection.CreateAnswer(nil)
-		if err != nil {
-			panic(err)
-		}
-
-		// Create channel that is blocked until ICE Gathering is complete
-		gatherComplete := webrtc.GatheringCompletePromise(peerConnection)
-
-		// Sets the LocalDescription, and start our UDP listeners
-		err = peerConnection.SetLocalDescription(answer)
-		if err != nil {
-			panic(err)
-		}
-
-		fmt.Println("waiting for gathering")
-		// Block until ICE Gathering is complete, disabling trickle ICE
-		// we do this because we only can exchange one signaling message
-		// TODO: in a production application you should exchange ICE Candidates via OnICECandidate
-		<-gatherComplete
-
-		// Push answer to signaling-server
-		answerSessionDescr := encode(peerConnection.LocalDescription())
-		fmt.Println("putting answer ...")
-		fmt.Printf("%s\n", answerSessionDescr)
-		_, err = http.Post(genUrl("/answer"), "text/plain", strings.NewReader(answerSessionDescr))
-		if err != nil {
-			fmt.Printf("E: while posting answer to signaling server: %v\n", err)
-		}
-
-		<-reset
-	}
-}
-
-func getOfferFromServer() string {
-	resp, err := http.Get(genUrl("/offer"))
-	if err != nil {
-		fmt.Printf("E: while getting offer from server: %v\n", err)
-		return ""
-	}
-	respBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		fmt.Printf("E: while reading offer from server: %v\n", err)
-		return ""
-	}
-	return string(respBody)
-}
-func getICEServersFromServer() ([]webrtc.ICEServer, error) {
-	resp, err := http.Get(genUrl("/ice-config"))
-	if err != nil {
-		return nil, fmt.Errorf("E: while getting ice-config from server: %v\n", err)
-	}
-	respBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("E: while reading offer from server: %v\n", err)
-	}
-	var iceServers []webrtc.ICEServer
-	err = json.Unmarshal(respBody, &iceServers)
-	return iceServers, nil
-}
-
-func repeat(fn func() string, delay time.Duration) string {
-	for {
-		result := fn()
-		if len(result) > 0 {
-			return result
-		}
-		fmt.Printf("did not get a result, rerun in %v ...\n", delay)
-		time.Sleep(delay)
-	}
-}
-
-func resetSession() {
-	fmt.Println("reset session ...")
-	_, err := http.Post(genUrl("/answer"), "text/plain", strings.NewReader(""))
-	if err != nil {
-		fmt.Printf("E: while resetting answer on signaling server: %v\n", err)
-		os.Exit(1)
-	}
-	_, err = http.Post(genUrl("/offer"), "text/plain", strings.NewReader(""))
-	if err != nil {
-		fmt.Printf("E: while resetting offer on signaling server: %v\n", err)
-		os.Exit(1)
-	}
-}
-
-// JSON encode + base64 a SessionDescription
-func encode(obj *webrtc.SessionDescription) string {
-	b, err := json.Marshal(obj)
-	if err != nil {
-		panic(err)
-	}
-
-	return base64.StdEncoding.EncodeToString(b)
-}
-
-// Decode a base64 and unmarshal JSON into a SessionDescription
-func decode(in string, obj *webrtc.SessionDescription) {
-	b, err := base64.StdEncoding.DecodeString(in)
-	if err != nil {
-		panic(err)
-	}
-
-	if err = json.Unmarshal(b, obj); err != nil {
-		panic(err)
-	}
-}
-
-func genUrl(relPath string) string {
-	return fmt.Sprintf("http://165.22.91.102:8080/d43981bd-3822-4127-8cec-662f9a4d54f0%s", relPath)
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, os.Interrupt)
+	// TODO handle shutdown
+	// go func() {
+	// 	for sig := range c {
+	// 	}
+	// }()
+	<-c
+	fmt.Println("good bye!")
 }

--- a/runner.go
+++ b/runner.go
@@ -14,7 +14,7 @@ type ExecutionInfo struct {
 	Output     []byte
 }
 
-func run(screen Screen, commandName string, args []string) {
+func run(screen Screen, done chan bool, commandName string, args []string) {
 	go screen.Init()
 	var count int64
 	for {
@@ -39,5 +39,9 @@ func run(screen Screen, commandName string, args []string) {
 			Output:     output,
 		})
 		time.Sleep(2 * time.Second)
+		if count >= 40 {
+			done <- true
+			break
+		}
 	}
 }

--- a/screen.go
+++ b/screen.go
@@ -1,5 +1,7 @@
 package main
 
-type Screen struct {
-	text string
+type Screen interface {
+	Init()
+	SetOutput(info ExecutionInfo)
+	SetError(err error)
 }

--- a/simple-counter.sh
+++ b/simple-counter.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 
-COUNT_TO="$1"
+SLEEP="$1"
+COUNT_TO="$2"
 
 i=1
 while [ $i -le $COUNT_TO ]; do
     echo "counting: $i"
     i=$((i+1))
-    sleep 1
+    sleep $SLEEP
 done

--- a/system-tests/simpleCounter_test.go
+++ b/system-tests/simpleCounter_test.go
@@ -18,6 +18,7 @@ import (
 const debug = false
 
 func TestSimpleCounter(t *testing.T) {
+	fmt.Println("test started")
 	go run()
 	time.Sleep(2 * time.Second)
 	var browser *rod.Browser
@@ -42,7 +43,18 @@ func TestSimpleCounter(t *testing.T) {
 
 		defer browser.MustClose()
 	} else {
-		browser = rod.New().MustConnect()
+		fmt.Println("browser connecting")
+		l := launcher.New().
+			NoSandbox(true).
+			Headless(true)
+		defer l.Cleanup()
+
+		fmt.Println("browser connecting 2")
+		url := l.MustLaunch()
+		browser = rod.New().ControlURL(url).MustConnect()
+		// browser = rod.New().MustConnect()
+		fmt.Println("browser connected")
+		defer browser.MustClose()
 	}
 	page := browser.MustPage(genUrl("/"))
 	termElem := page.MustElement("#terminal")
@@ -67,7 +79,6 @@ func run() {
 		// fmt.Printf("got output line from command: %v\n", scanner.Text())
 	}
 	cmd.Wait()
-
 }
 
 func genUrl(relPath string) string {

--- a/webrtc-screen.go
+++ b/webrtc-screen.go
@@ -1,0 +1,209 @@
+package main
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/pion/webrtc/v4"
+)
+
+type WebRTCScreen struct {
+	latestExecution ExecutionInfo
+}
+
+func (screen *WebRTCScreen) Init() {
+	resetSession()
+	ICEServers, err := getICEServersFromServer()
+	if err != nil {
+		fmt.Printf("E: while getting ICEServers-config: %v\n", err)
+		panic("check your internet connection")
+	}
+	config := webrtc.Configuration{
+		ICEServers: ICEServers,
+	}
+
+	reset := make(chan bool, 1)
+	for {
+		// Create a new RTCPeerConnection
+		peerConnection, err := webrtc.NewPeerConnection(config)
+		if err != nil {
+			panic(err)
+		}
+		defer func() {
+			if cErr := peerConnection.Close(); cErr != nil {
+				fmt.Printf("cannot close peerConnection: %v\n", cErr)
+			}
+		}()
+
+		peerConnection.OnConnectionStateChange(func(s webrtc.PeerConnectionState) {
+			fmt.Printf("Peer Connection State has changed: %s\n", s.String())
+
+			if s == webrtc.PeerConnectionStateFailed {
+				fmt.Println("Peer Connection has gone to failed exiting")
+				resetSession()
+				reset <- true
+			}
+
+			if s == webrtc.PeerConnectionStateClosed {
+				fmt.Println("Peer Connection has gone to closed exiting")
+				resetSession()
+				reset <- true
+			}
+		})
+
+		peerConnection.OnDataChannel(func(d *webrtc.DataChannel) {
+			fmt.Printf("New DataChannel %s %d\n", d.Label(), d.ID())
+
+			d.OnOpen(func() {
+				fmt.Printf("Data channel '%s'-'%d' open.\n", d.Label(), d.ID())
+
+				ticker := time.NewTicker(2 * time.Second)
+				defer ticker.Stop()
+				for range ticker.C {
+					// fmt.Printf("Sending '%s'\n", screen.text)
+					err = d.SendText(string(screen.latestExecution.Output))
+					if err != nil {
+						fmt.Printf("E: while sending: %v\n", err)
+						break
+					}
+				}
+			})
+
+			d.OnMessage(func(msg webrtc.DataChannelMessage) {
+				fmt.Printf("Message from DataChannel '%s': '%s'\n", d.Label(), string(msg.Data))
+			})
+		})
+
+		// Waiting for and Import client-offer from signaling-server
+		offerData := repeat(getOfferFromServer, 2*time.Second)
+		offer := webrtc.SessionDescription{}
+		decode(offerData, &offer)
+		err = peerConnection.SetRemoteDescription(offer)
+		if err != nil {
+			panic(err)
+		}
+
+		// Create an answer
+		answer, err := peerConnection.CreateAnswer(nil)
+		if err != nil {
+			panic(err)
+		}
+
+		// Create channel that is blocked until ICE Gathering is complete
+		gatherComplete := webrtc.GatheringCompletePromise(peerConnection)
+
+		// Sets the LocalDescription, and start our UDP listeners
+		err = peerConnection.SetLocalDescription(answer)
+		if err != nil {
+			panic(err)
+		}
+
+		fmt.Println("waiting for gathering")
+		// Block until ICE Gathering is complete, disabling trickle ICE
+		// we do this because we only can exchange one signaling message
+		// TODO: in a production application you should exchange ICE Candidates via OnICECandidate
+		<-gatherComplete
+
+		// Push answer to signaling-server
+		answerSessionDescr := encode(peerConnection.LocalDescription())
+		fmt.Println("putting answer ...")
+		fmt.Printf("%s\n", answerSessionDescr)
+		_, err = http.Post(genUrl("/answer"), "text/plain", strings.NewReader(answerSessionDescr))
+		if err != nil {
+			fmt.Printf("E: while posting answer to signaling server: %v\n", err)
+		}
+
+		<-reset
+	}
+}
+func (screen *WebRTCScreen) SetOutput(info ExecutionInfo) {
+	screen.latestExecution = info
+}
+
+func (screen *WebRTCScreen) SetError(err error) {
+	fmt.Println("SetError not yet implemented")
+}
+
+func getOfferFromServer() string {
+	resp, err := http.Get(genUrl("/offer"))
+	if err != nil {
+		fmt.Printf("E: while getting offer from server: %v\n", err)
+		return ""
+	}
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		fmt.Printf("E: while reading offer from server: %v\n", err)
+		return ""
+	}
+	return string(respBody)
+}
+func getICEServersFromServer() ([]webrtc.ICEServer, error) {
+	resp, err := http.Get(genUrl("/ice-config"))
+	if err != nil {
+		return nil, fmt.Errorf("E: while getting ice-config from server: %v\n", err)
+	}
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("E: while reading offer from server: %v\n", err)
+	}
+	var iceServers []webrtc.ICEServer
+	err = json.Unmarshal(respBody, &iceServers)
+	return iceServers, nil
+}
+
+func repeat(fn func() string, delay time.Duration) string {
+	for {
+		result := fn()
+		if len(result) > 0 {
+			return result
+		}
+		fmt.Printf("did not get a result, rerun in %v ...\n", delay)
+		time.Sleep(delay)
+	}
+}
+
+func resetSession() {
+	fmt.Println("reset session ...")
+	_, err := http.Post(genUrl("/answer"), "text/plain", strings.NewReader(""))
+	if err != nil {
+		fmt.Printf("E: while resetting answer on signaling server: %v\n", err)
+		os.Exit(1)
+	}
+	_, err = http.Post(genUrl("/offer"), "text/plain", strings.NewReader(""))
+	if err != nil {
+		fmt.Printf("E: while resetting offer on signaling server: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+// JSON encode + base64 a SessionDescription
+func encode(obj *webrtc.SessionDescription) string {
+	b, err := json.Marshal(obj)
+	if err != nil {
+		panic(err)
+	}
+
+	return base64.StdEncoding.EncodeToString(b)
+}
+
+// Decode a base64 and unmarshal JSON into a SessionDescription
+func decode(in string, obj *webrtc.SessionDescription) {
+	b, err := base64.StdEncoding.DecodeString(in)
+	if err != nil {
+		panic(err)
+	}
+
+	if err = json.Unmarshal(b, obj); err != nil {
+		panic(err)
+	}
+}
+
+func genUrl(relPath string) string {
+	return fmt.Sprintf("http://165.22.91.102:8080/d43981bd-3822-4127-8cec-662f9a4d54f0%s", relPath)
+}


### PR DESCRIPTION
changes:
- switched to repeat-mode:
    - command is not just executed once, but now gets executed in a loop with a static 2s delay, just like `gnu-watch`
- introduced `ExecutionInfo` struct
    - not just sending a simple string to the webrtc-client anymore, but now sending a struct with more infos/details to the execution
- set static max run-count
    - the `rwatch` will now stop aber 40 executions of the given command, this helps with integrationtesting for now, there will be a cmd-line-option later to specify a max count but infinite by default
- switched to go-rod launcher 
    - had to switch to go-rod launcher as i had problems with running it on github¬actions cause chromium-installation on ghactions hasnt set suid (https://github.com/go-rod/rod/issues/1070)