### PR TITLE
using command from cli-args-input, instead of hardcoded one

### DIFF
--- a/main.go
+++ b/main.go
@@ -8,6 +8,8 @@ import (
 )
 
 func main() {
+	command, args := parseArgs(os.Args)
+	fmt.Printf("command: %s, args: %v\n", command, args)
 	screen := WebRTCScreen{}
 
 	runnerDone := make(chan bool, 1)
@@ -16,7 +18,7 @@ func main() {
 		executor: func(name string, arg ...string) Executor {
 			return &OsExecutor{exec.Command(name, arg...)}
 		}}
-	go runner.Run(&screen, runnerDone, "/bin/bash", []string{"./simple-counter.sh", "0", "5"})
+	go runner.Run(&screen, runnerDone, command, args)
 
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, os.Interrupt)
@@ -30,4 +32,18 @@ func main() {
 	case <-runnerDone:
 	}
 	fmt.Println("good bye!")
+}
+
+func parseArgs(args []string) (string, []string) {
+	position := -1
+	for i, arg := range args {
+		if arg == "--" {
+			position = i + 1
+			break
+		}
+	}
+	if position == -1 {
+		panic("you need to have -- as command separator")
+	}
+	return args[position], args[position+1:]
 }

--- a/system-tests/simpleCounter_test.go
+++ b/system-tests/simpleCounter_test.go
@@ -18,7 +18,7 @@ import (
 const debug = false
 
 func TestSimpleCounter(t *testing.T) {
-	go run()
+	go run("/bin/bash", "./simple-counter.sh", "0", "5")
 	time.Sleep(2 * time.Second)
 	var browser *rod.Browser
 	if debug {
@@ -57,8 +57,8 @@ func TestSimpleCounter(t *testing.T) {
 	assert.Equal(t, "counting: 1\ncounting: 2\ncounting: 3\ncounting: 4\ncounting: 5\n", termElem.MustText())
 }
 
-func run() {
-	cmd := exec.Command("go", "run", ".", "--", "/bin/bash", "./simpleCounter.sh", "0", "5")
+func run(command ...string) {
+	cmd := exec.Command("go", append([]string{"run", ".", "--"}, command...)...)
 	cmd.Dir = ".."
 	reader, err := cmd.StdoutPipe()
 	if err != nil {
@@ -72,7 +72,7 @@ func run() {
 	}
 	scanner := bufio.NewScanner(reader)
 	for scanner.Scan() {
-		fmt.Printf("got output line from command: %v\n", scanner.Text())
+		// fmt.Printf("got output line from command: %v\n", scanner.Text())
 	}
 	cmd.Wait()
 }

--- a/system-tests/simpleCounter_test.go
+++ b/system-tests/simpleCounter_test.go
@@ -58,7 +58,7 @@ func TestSimpleCounter(t *testing.T) {
 }
 
 func run() {
-	cmd := exec.Command("go", "run", ".")
+	cmd := exec.Command("go", "run", ".", "--", "/bin/bash", "./simpleCounter.sh", "0", "5")
 	cmd.Dir = ".."
 	reader, err := cmd.StdoutPipe()
 	if err != nil {
@@ -72,7 +72,7 @@ func run() {
 	}
 	scanner := bufio.NewScanner(reader)
 	for scanner.Scan() {
-		// fmt.Printf("got output line from command: %v\n", scanner.Text())
+		fmt.Printf("got output line from command: %v\n", scanner.Text())
 	}
 	cmd.Wait()
 }

--- a/webrtc_screen.go
+++ b/webrtc_screen.go
@@ -128,7 +128,7 @@ func (screen *WebRTCScreen) SetOutput(info ExecutionInfo) {
 }
 
 func (screen *WebRTCScreen) SetError(err error) {
-	fmt.Println("SetError not yet implemented")
+	fmt.Printf("SetError not yet implemented, got: %v\n", err)
 }
 
 func getOfferFromServer() string {


### PR DESCRIPTION
changes:
- up until now there was a hardcoded command that automatically starts. that was easier for the starting phase to build the basic setup. now the command must be passed from outside (cli-args)